### PR TITLE
Add dynamic voice channel creation via JDA

### DIFF
--- a/src/main/kotlin/com/lukehemmin/lukeVanilla/Main.kt
+++ b/src/main/kotlin/com/lukehemmin/lukeVanilla/Main.kt
@@ -268,6 +268,9 @@ class Main : JavaPlugin() {
             // VoiceChannelTextListener 초기화 및 리스너 등록
             discordBot.jda.addEventListener(VoiceChannelTextListener(this))
 
+            // DynamicVoiceChannelManager 초기화 및 리스너 등록
+            discordBot.jda.addEventListener(DynamicVoiceChannelManager(database))
+
             // ItemRestoreLogger 초기화
             itemRestoreLogger = ItemRestoreLogger(database, this, discordBot.jda)
 

--- a/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Discord/DynamicVoiceChannelManager.kt
+++ b/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Discord/DynamicVoiceChannelManager.kt
@@ -1,0 +1,68 @@
+package com.lukehemmin.lukeVanilla.System.Discord
+
+import com.lukehemmin.lukeVanilla.System.Database.Database
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import java.util.EnumSet
+
+/**
+ * Listener that creates temporary voice channels when a user joins a trigger channel.
+ * The trigger channel and target category IDs are loaded from the Settings table.
+ */
+class DynamicVoiceChannelManager(private val database: Database) : ListenerAdapter() {
+
+    private val createdChannels = mutableSetOf<String>()
+
+    // Trigger voice channel IDs
+    private val triggerChannel1 = database.getSettingValue("TRIGGER_VOICE_CHANNEL_ID_1")
+    private val triggerChannel2 = database.getSettingValue("TRIGGER_VOICE_CHANNEL_ID_2")
+
+    // Category IDs where the new channels will be created
+    private val category1 = database.getSettingValue("VOICE_CATEGORY_ID_1")
+    private val category2 = database.getSettingValue("VOICE_CATEGORY_ID_2")
+
+    override fun onGuildVoiceUpdate(event: GuildVoiceUpdateEvent) {
+        val member = event.member
+        val guild = event.guild
+        val joined = event.channelJoined?.asVoiceChannel()
+        val left = event.channelLeft?.asVoiceChannel()
+
+        // When joining a trigger channel, create a new voice channel for the user
+        if (joined != null) {
+            val categoryId = when (joined.id) {
+                triggerChannel1 -> category1
+                triggerChannel2 -> category2
+                else -> null
+            }
+
+            if (categoryId != null) {
+                val category = guild.getCategoryById(categoryId)
+                category?.createVoiceChannel("${member.effectiveName}의 방")
+                    ?.addPermissionOverride(
+                        member,
+                        EnumSet.of(
+                            Permission.VIEW_CHANNEL,
+                            Permission.MANAGE_CHANNEL,
+                            Permission.MANAGE_PERMISSIONS,
+                            Permission.VOICE_CONNECT
+                        ),
+                        null
+                    )
+                    ?.queue { channel ->
+                        createdChannels.add(channel.id)
+                        guild.moveVoiceMember(member, channel).queue()
+                    }
+            }
+        }
+
+        // Remove empty created channels when everyone leaves
+        if (left != null && createdChannels.contains(left.id)) {
+            if (left.members.isEmpty()) {
+                createdChannels.remove(left.id)
+                left.delete().queue()
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `DynamicVoiceChannelManager` listener that creates temporary voice channels
- register the new listener in `Main.kt`
- compiled project to ensure no errors

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6864a8e27e008326be7c4c59616e4f2e