### PR TITLE
Add persistent dynamic voice channel tracking

### DIFF
--- a/src/main/kotlin/com/lukehemmin/lukeVanilla/Main.kt
+++ b/src/main/kotlin/com/lukehemmin/lukeVanilla/Main.kt
@@ -268,6 +268,11 @@ class Main : JavaPlugin() {
             // VoiceChannelTextListener 초기화 및 리스너 등록
             discordBot.jda.addEventListener(VoiceChannelTextListener(this))
 
+            // DynamicVoiceChannelManager 초기화 및 리스너 등록 (야생서버 전용)
+            if (serviceType == "Vanilla") {
+                discordBot.jda.addEventListener(DynamicVoiceChannelManager(database))
+            }
+
             // ItemRestoreLogger 초기화
             itemRestoreLogger = ItemRestoreLogger(database, this, discordBot.jda)
 

--- a/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Database/DatabaseInitializer.kt
+++ b/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Database/DatabaseInitializer.kt
@@ -17,6 +17,7 @@ class DatabaseInitializer(private val database: Database) {
         createValentineItemReceiveTable()
         createTitokerMessageSettingTable()
         createVoiceChannelMessageSettingTable()
+        createDynamicVoiceChannelTable()
         createSupportChatLinkTable()
         createNextseasonItemTable()
         createShopsTable()
@@ -311,6 +312,21 @@ class DatabaseInitializer(private val database: Database) {
                 `IsEnabled` BOOLEAN DEFAULT false
             )
             """
+            )
+        }
+    }
+
+    private fun createDynamicVoiceChannelTable() {
+        database.getConnection().use { connection ->
+            val statement = connection.createStatement()
+            statement.executeUpdate(
+                """
+            CREATE TABLE IF NOT EXISTS Dynamic_Voice_Channel (
+                `guild_id` VARCHAR(30) NOT NULL,
+                `channel_id` VARCHAR(30) PRIMARY KEY,
+                `owner_id` VARCHAR(30) NOT NULL
+            )
+            """.trimIndent()
             )
         }
     }

--- a/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Discord/DynamicVoiceChannelManager.kt
+++ b/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Discord/DynamicVoiceChannelManager.kt
@@ -15,6 +15,9 @@ class DynamicVoiceChannelManager(private val database: Database) : ListenerAdapt
 
     private val createdChannels = mutableSetOf<String>()
 
+    /** Discord 채널 이름 최대 길이 대비 여유를 두기 위한 값 */
+    private val MAX_NAME_LENGTH = 96
+
     // Trigger voice channel IDs
     private val triggerChannel1 = database.getSettingValue("TRIGGER_VOICE_CHANNEL_ID_1")
     private val triggerChannel2 = database.getSettingValue("TRIGGER_VOICE_CHANNEL_ID_2")
@@ -61,7 +64,7 @@ class DynamicVoiceChannelManager(private val database: Database) : ListenerAdapt
             if (categoryId != null) {
                 val category = guild.getCategoryById(categoryId)
                 val baseName = "${member.effectiveName}의 방"
-                val channelName = if (baseName.length > 96) baseName.take(96) else baseName
+                val channelName = if (baseName.length > MAX_NAME_LENGTH) baseName.take(MAX_NAME_LENGTH) else baseName
                 category?.createVoiceChannel(channelName)
                     ?.addPermissionOverride(
                         member,

--- a/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Discord/DynamicVoiceChannelManager.kt
+++ b/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Discord/DynamicVoiceChannelManager.kt
@@ -1,0 +1,92 @@
+package com.lukehemmin.lukeVanilla.System.Discord
+
+import com.lukehemmin.lukeVanilla.System.Database.Database
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.events.guild.GuildReadyEvent
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import java.util.EnumSet
+
+/**
+ * Listener that creates temporary voice channels when a user joins a trigger channel.
+ * The trigger channel and target category IDs are loaded from the Settings table.
+ */
+class DynamicVoiceChannelManager(private val database: Database) : ListenerAdapter() {
+
+    private val createdChannels = mutableSetOf<String>()
+
+    // Trigger voice channel IDs
+    private val triggerChannel1 = database.getSettingValue("TRIGGER_VOICE_CHANNEL_ID_1")
+    private val triggerChannel2 = database.getSettingValue("TRIGGER_VOICE_CHANNEL_ID_2")
+
+    // Category IDs where the new channels will be created
+    private val category1 = database.getSettingValue("VOICE_CATEGORY_ID_1")
+    private val category2 = database.getSettingValue("VOICE_CATEGORY_ID_2")
+
+    override fun onGuildReady(event: GuildReadyEvent) {
+        // Load existing dynamic channels from the database and clean up stale ones
+        val storedChannels = database.getDynamicVoiceChannels(event.guild.id)
+        for (record in storedChannels) {
+            val channel = event.guild.getVoiceChannelById(record.channelId)
+            if (channel == null) {
+                // Channel no longer exists
+                database.deleteDynamicVoiceChannel(record.channelId)
+                continue
+            }
+
+            if (channel.members.isEmpty()) {
+                // Delete empty channels left from previous session
+                database.deleteDynamicVoiceChannel(channel.id)
+                channel.delete().queue()
+            } else {
+                createdChannels.add(channel.id)
+            }
+        }
+    }
+
+    override fun onGuildVoiceUpdate(event: GuildVoiceUpdateEvent) {
+        val member = event.member
+        val guild = event.guild
+        val joined = event.channelJoined?.asVoiceChannel()
+        val left = event.channelLeft?.asVoiceChannel()
+
+        // When joining a trigger channel, create a new voice channel for the user
+        if (joined != null) {
+            val categoryId = when (joined.id) {
+                triggerChannel1 -> category1
+                triggerChannel2 -> category2
+                else -> null
+            }
+
+            if (categoryId != null) {
+                val category = guild.getCategoryById(categoryId)
+                category?.createVoiceChannel("${member.effectiveName}의 방")
+                    ?.addPermissionOverride(
+                        member,
+                        EnumSet.of(
+                            Permission.VIEW_CHANNEL,
+                            Permission.MANAGE_CHANNEL,
+                            Permission.MANAGE_PERMISSIONS,
+                            Permission.VOICE_CONNECT
+                        ),
+                        null
+                    )
+                    ?.queue { channel ->
+                        createdChannels.add(channel.id)
+                        database.insertDynamicVoiceChannel(guild.id, channel.id, member.id)
+                        guild.moveVoiceMember(member, channel).queue()
+                    }
+            }
+        }
+
+        // Remove empty created channels when everyone leaves
+        if (left != null && createdChannels.contains(left.id)) {
+            if (left.members.isEmpty()) {
+                createdChannels.remove(left.id)
+                database.deleteDynamicVoiceChannel(left.id)
+                left.delete().queue()
+            }
+        }
+    }
+}
+

--- a/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Discord/DynamicVoiceChannelManager.kt
+++ b/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Discord/DynamicVoiceChannelManager.kt
@@ -60,7 +60,9 @@ class DynamicVoiceChannelManager(private val database: Database) : ListenerAdapt
 
             if (categoryId != null) {
                 val category = guild.getCategoryById(categoryId)
-                category?.createVoiceChannel("${member.effectiveName}의 방")
+                val baseName = "${member.effectiveName}의 방"
+                val channelName = if (baseName.length > 96) baseName.take(96) else baseName
+                category?.createVoiceChannel(channelName)
                     ?.addPermissionOverride(
                         member,
                         EnumSet.of(


### PR DESCRIPTION
## Summary
- add new database table `Dynamic_Voice_Channel` to track temporary Discord channels
- persist created voice channel IDs and clean them up on startup
- only enable the dynamic channel manager on the Vanilla server

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6864a8e27e008326be7c4c59616e4f2e