### PR TITLE
Add persistent dynamic voice channel management

### DIFF
--- a/src/main/kotlin/com/lukehemmin/lukeVanilla/Main.kt
+++ b/src/main/kotlin/com/lukehemmin/lukeVanilla/Main.kt
@@ -268,8 +268,16 @@ class Main : JavaPlugin() {
             // VoiceChannelTextListener 초기화 및 리스너 등록
             discordBot.jda.addEventListener(VoiceChannelTextListener(this))
 
-            // DynamicVoiceChannelManager 초기화 및 리스너 등록
-            discordBot.jda.addEventListener(DynamicVoiceChannelManager(database))
+            // DynamicVoiceChannelManager는 야생 서버에서만 실행
+            if (serviceType == "Vanilla") {
+                val guildId = database.getSettingValue("DiscordServerID")
+                guildId?.let {
+                    discordBot.jda.addEventListener(
+                        DynamicVoiceChannelManager(database, discordBot.jda, it)
+                    )
+                    logger.info("[DynamicVoiceChannelManager] 야생 서버에서 음성 채널 관리 기능을 활성화했습니다.")
+                }
+            }
 
             // ItemRestoreLogger 초기화
             itemRestoreLogger = ItemRestoreLogger(database, this, discordBot.jda)

--- a/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Database/Database.kt
+++ b/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Database/Database.kt
@@ -287,6 +287,42 @@ class Database(private val plugin: Main, config: FileConfiguration) {
         }
     }
 
+    fun addDynamicVoiceChannel(channelId: String, creatorId: String) {
+        val query = "INSERT INTO Dynamic_Voice_Channel (channel_id, creator_id) VALUES (?, ?)"
+        getConnection().use { connection ->
+            connection.prepareStatement(query).use { statement ->
+                statement.setString(1, channelId)
+                statement.setString(2, creatorId)
+                statement.executeUpdate()
+            }
+        }
+    }
+
+    fun removeDynamicVoiceChannel(channelId: String) {
+        val query = "DELETE FROM Dynamic_Voice_Channel WHERE channel_id = ?"
+        getConnection().use { connection ->
+            connection.prepareStatement(query).use { statement ->
+                statement.setString(1, channelId)
+                statement.executeUpdate()
+            }
+        }
+    }
+
+    fun getDynamicVoiceChannels(): Set<String> {
+        val channels = mutableSetOf<String>()
+        val query = "SELECT channel_id FROM Dynamic_Voice_Channel"
+        getConnection().use { connection ->
+            connection.prepareStatement(query).use { statement ->
+                statement.executeQuery().use { resultSet ->
+                    while (resultSet.next()) {
+                        channels.add(resultSet.getString("channel_id"))
+                    }
+                }
+            }
+        }
+        return channels
+    }
+
     fun getDiscordIDByUUID(uuid: String): String? {
         val query = "SELECT DiscordID FROM Player_Data WHERE UUID = ?"
         getConnection().use { connection ->

--- a/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Database/DatabaseInitializer.kt
+++ b/src/main/kotlin/com/lukehemmin/lukeVanilla/System/Database/DatabaseInitializer.kt
@@ -17,6 +17,7 @@ class DatabaseInitializer(private val database: Database) {
         createValentineItemReceiveTable()
         createTitokerMessageSettingTable()
         createVoiceChannelMessageSettingTable()
+        createDynamicVoiceChannelTable()
         createSupportChatLinkTable()
         createNextseasonItemTable()
         createShopsTable()
@@ -309,6 +310,21 @@ class DatabaseInitializer(private val database: Database) {
             CREATE TABLE IF NOT EXISTS Voice_Channel_Message_Setting (
                 `UUID` VARCHAR(36) PRIMARY KEY,
                 `IsEnabled` BOOLEAN DEFAULT false
+            )
+            """
+            )
+        }
+    }
+
+    private fun createDynamicVoiceChannelTable() {
+        database.getConnection().use { connection ->
+            val statement = connection.createStatement()
+            statement.executeUpdate(
+                """
+            CREATE TABLE IF NOT EXISTS Dynamic_Voice_Channel (
+                `channel_id` VARCHAR(30) PRIMARY KEY,
+                `creator_id` VARCHAR(30) NOT NULL,
+                `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
             """
             )


### PR DESCRIPTION
## Summary
- only register `DynamicVoiceChannelManager` on the vanilla server
- create new DB table `Dynamic_Voice_Channel` and add CRUD helpers
- load saved channels on startup and clean up empty ones
- persist created channels and delete on empty

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6864bacecb4483269caa8ff06bf3d4ac